### PR TITLE
Add unit tests for Base64 and Charsetfunctions

### DIFF
--- a/src/test/java/org/java_websocket/util/Base64Test.java
+++ b/src/test/java/org/java_websocket/util/Base64Test.java
@@ -1,0 +1,68 @@
+package org.java_websocket.util;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class Base64Test {
+
+	@Rule public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testEncodeBytes() throws IOException {
+		Assert.assertEquals("", Base64.encodeBytes(new byte[0]));
+		Assert.assertEquals("QHE=",
+			Base64.encodeBytes(new byte[] {49, 121, 64, 113, -63, 43, -24, 62, 4, 48}, 2, 2, 0));
+	}
+
+	@Test
+	public void testEncodeBytes2() throws IOException {
+		thrown.expect(IllegalArgumentException.class);
+		Base64.encodeBytes(new byte[0], -2, -2, -56);
+	}
+
+	@Test
+	public void testEncodeBytes3() throws IOException {
+		thrown.expect(IllegalArgumentException.class);
+		Base64.encodeBytes(new byte[] {64, -128, 32, 18, 16, 16, 0, 18, 16},
+			2064072977, -2064007440, 10);
+	}
+
+	@Test
+	public void testEncodeBytes4() {
+		thrown.expect(NullPointerException.class);
+		Base64.encodeBytes(null);
+	}
+
+	@Test
+	public void testEncodeBytes5() throws IOException {
+		thrown.expect(IllegalArgumentException.class);
+		Base64.encodeBytes(null, 32766, 0, 8);
+	}
+
+	@Test
+	public void testEncodeBytesToBytes1() throws IOException {
+		Assert.assertArrayEquals(new byte[] {95, 68, 111, 78, 55, 45, 61, 61},
+			Base64.encodeBytesToBytes(new byte[] {-108, -19, 24, 32}, 0, 4, 32));
+		Assert.assertArrayEquals(new byte[] {95, 68, 111, 78, 55, 67, 111, 61},
+			Base64.encodeBytesToBytes(new byte[] {-108, -19, 24, 32, -35}, 0, 5, 40));
+		Assert.assertArrayEquals(new byte[] {95, 68, 111, 78, 55, 67, 111, 61},
+			Base64.encodeBytesToBytes(new byte[] {-108, -19, 24, 32, -35}, 0, 5, 32));
+		Assert.assertArrayEquals(new byte[] {87, 50, 77, 61},
+			Base64.encodeBytesToBytes(new byte[] {115, 42, 123, 99, 10, -33, 75, 30, 91, 99}, 8, 2, 48));
+		Assert.assertArrayEquals(new byte[] {87, 50, 77, 61},
+			Base64.encodeBytesToBytes(new byte[] {115, 42, 123, 99, 10, -33, 75, 30, 91, 99}, 8, 2, 56));
+		Assert.assertArrayEquals(new byte[] {76, 53, 66, 61},
+			Base64.encodeBytesToBytes(new byte[] {113, 42, 123, 99, 10, -33, 75, 30, 88, 99}, 8, 2, 36));Assert.assertArrayEquals(new byte[] {87, 71, 77, 61},
+			Base64.encodeBytesToBytes(new byte[] {113, 42, 123, 99, 10, -33, 75, 30, 88, 99}, 8, 2, 4));
+	}
+
+	@Test
+	public void testEncodeBytesToBytes2() throws IOException {
+		thrown.expect(IllegalArgumentException.class);
+		Base64.encodeBytesToBytes(new byte[] {83, 10,	91, 67, 42, -1, 107, 62, 91, 67}, 8, 6, 26);
+	}
+}

--- a/src/test/java/org/java_websocket/util/CharsetfunctionsTest.java
+++ b/src/test/java/org/java_websocket/util/CharsetfunctionsTest.java
@@ -1,0 +1,52 @@
+package org.java_websocket.util;
+
+import org.java_websocket.exceptions.InvalidDataException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class CharsetfunctionsTest {
+
+  @Test
+  public void testAsciiBytes() {
+    Assert.assertArrayEquals(new byte[] {102, 111, 111}, Charsetfunctions.asciiBytes("foo"));
+  }
+
+  @Test
+  public void testStringUtf8ByteBuffer() throws InvalidDataException {
+    Assert.assertEquals("foo", Charsetfunctions.stringUtf8(ByteBuffer.wrap(new byte[] {102, 111, 111})));
+  }
+
+
+  @Test
+  public void testIsValidUTF8off() {
+    Assert.assertFalse(Charsetfunctions.isValidUTF8(ByteBuffer.wrap(new byte[] {100}), 2));
+    Assert.assertFalse(Charsetfunctions.isValidUTF8(ByteBuffer.wrap(new byte[] {(byte) 128}), 0));
+
+    Assert.assertTrue(Charsetfunctions.isValidUTF8(ByteBuffer.wrap(new byte[] {100}), 0));
+  }
+
+  @Test
+  public void testIsValidUTF8() {
+    Assert.assertFalse(Charsetfunctions.isValidUTF8(ByteBuffer.wrap(new byte[] {(byte) 128})));
+
+    Assert.assertTrue(Charsetfunctions.isValidUTF8(ByteBuffer.wrap(new byte[] {100})));
+  }
+
+  @Test
+  public void testStringAscii1() {
+    Assert.assertEquals("oBar", Charsetfunctions.stringAscii(new byte[] {102, 111, 111, 66, 97, 114}, 2, 4));
+
+  }
+
+  @Test
+  public void testStringAscii2() {
+    Assert.assertEquals("foo", Charsetfunctions.stringAscii(new byte[] {102, 111, 111}));
+  }
+
+  @Test
+  public void testUtf8Bytes() {
+    Assert.assertArrayEquals(new byte[] {102, 111, 111, 66, 97, 114}, Charsetfunctions.utf8Bytes("fooBar"));
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hi,

I've analysed your code base and noticed that `org.java_websocket.util.Base64` and `org.java_websocket.util.Charsetfunctions` are not fully tested.

I've written some tests that cover these classes with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

## Motivation and Context
Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
